### PR TITLE
Fix: get proper extension from url with query string

### DIFF
--- a/link.js
+++ b/link.js
@@ -27,7 +27,7 @@ define(function () {
     }
 
     function getExtension(filename) {
-        var ext = filename.split('/').pop();
+        var ext = filename.split('/').pop().split('?').shift();
         return ext.indexOf('.') < 1 ? '' : ext.split('.').pop();
     }
 


### PR DESCRIPTION
getExtension function returned empty string when url had query string, so the component failed to load

eg.
```
define(['link!my-web-component.html?version=42'], function (wcElement) {
  // whatever
});
```